### PR TITLE
Fix DAP initialization deadlock by making launch request non-blocking

### DIFF
--- a/src/daemon/session.rs
+++ b/src/daemon/session.rs
@@ -225,17 +225,11 @@ impl DebugSession {
             "Sending DAP launch request"
         );
         
-        // For Python/debugpy, we need to use non-blocking launch because debugpy
-        // doesn't respond to launch until after configurationDone is sent.
-        // We send launch, wait for initialized, send configurationDone, then
-        // the launch response arrives.
-        if is_python {
-            client.launch_no_wait(launch_args).await?;
-            tracing::debug!("DAP launch request sent (no-wait mode for Python)");
-        } else {
-            client.launch(launch_args).await?;
-            tracing::debug!("DAP launch request successful");
-        }
+        // The DAP specification allows adapters to defer the launch response
+        // until after configurationDone is received. To prevent deadlocks with
+        // strict adapters (like debugpy and lldb-dap), we use a non-blocking launch.
+        client.launch_no_wait(launch_args).await?;
+        tracing::debug!("DAP launch request sent (no-wait mode)");
 
         // Wait for initialized event (comes after launch per DAP spec)
         tracing::debug!(timeout_secs = request_timeout.as_secs(), "Waiting for DAP initialized event");

--- a/src/dap/client.rs
+++ b/src/dap/client.rs
@@ -706,7 +706,53 @@ impl DapClient {
     /// configurationDone is sent. This sends the launch request but doesn't
     /// wait for the response.
     pub async fn launch_no_wait(&mut self, args: LaunchArguments) -> Result<i64> {
-        self.send_request("launch", Some(serde_json::to_value(&args)?)).await
+        let seq = self.next_seq();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        {
+            let mut pending_guard = self.pending.lock().await;
+            pending_guard.insert(seq, tx);
+        }
+
+        let request = serde_json::json!({
+            "seq": seq,
+            "type": "request",
+            "command": "launch",
+            "arguments": serde_json::to_value(&args)?
+        });
+
+        let json = serde_json::to_string(&request)?;
+        tracing::trace!("DAP >>> {}", json);
+
+        if let Err(e) = codec::write_message(&mut self.writer, &json).await {
+            let mut pending_guard = self.pending.lock().await;
+            pending_guard.remove(&seq);
+            return Err(e);
+        }
+
+        // Spawn a background task to await the response and log any failures
+        tokio::spawn(async move {
+            if let Ok(inner_result) = rx.await {
+                match inner_result {
+                    Ok(response) => {
+                        if !response.success {
+                            tracing::error!(
+                                "Launch request failed: {}",
+                                response.message.unwrap_or_else(|| "Unknown error".to_string())
+                            );
+                        } else {
+                            tracing::debug!("Launch request succeeded (async)");
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("Launch request resulted in an error: {}", e);
+                    }
+                }
+            } else {
+                tracing::debug!("Launch response channel closed before receiving a reply");
+            }
+        });
+
+        Ok(seq)
     }
 
     /// Attach to a running process


### PR DESCRIPTION
  **The Issue:**
  Currently, when trying to start a debugging session using Apple's lldb-dap (bundled with Xcode command line tools on macOS), the debugger-cli daemon hangs immediately and the client times out with: Error: Operation timed out after 0 seconds or timed out waiting for socket.


  **The Root Cause:**
  The issue stems from a deadlock during the DAP initialization handshake in src/daemon/session.rs.
  The code contained a workaround specifically for debugpy (Python) because it does not respond to the launch request until after it receives the configurationDone request. However, **Apple's lldb-dap exhibits the exact same behavior**.


  According to the official Microsoft DAP specification (https://microsoft.github.io/debug-adapter-protocol/overview#initialization):
  > "The client should not assume that the launch or attach request has completed (i.e. the response has been received) before the initialized event is sent. [...] In some implementations, the launch or attach response is not sent until after the configurationDone request is received."


  By awaiting the launch request synchronously for non-Python adapters, debugger-cli was deadlocking: the CLI was waiting for the launch response, while lldb-dap was waiting for configurationDone.


  **The Fix:**
   1. Universal Non-Blocking Launch (src/daemon/session.rs): Removed the if is_python condition and switched to using the launch_no_wait pattern universally for all debug adapters.
      This prevents strict adapters from deadlocking the initialization phase.
   2. Robust Async Error Handling (src/dap/client.rs): As suggested in code review, launch_no_wait was rewritten so that it no longer discards the response. It now registers a
      oneshot::channel for the sequence number and spawns a non-blocking tokio::spawn task to await the response. If the adapter immediately rejects the launch (e.g., missing
      executable or bad arguments), the background task catches success: false and properly logs the error using tracing::error!.

  Testing:
   - Verified that the daemon no longer hangs on macOS using Apple's lldb-dap.
   - Verified that launch failures from immediate responders (like gdb) are properly captured and logged instead of triggering an "unknown sequence number" warning.